### PR TITLE
Fix highlight_id initialization bug

### DIFF
--- a/src/scraper/posts.py
+++ b/src/scraper/posts.py
@@ -547,12 +547,12 @@ class PostManager:
             
             ## Texthervorhebung
             highlight = None
+            highlight_id = None
             highlight_div = comment.find('div', {'id': re.compile(r'highlight-\d+')})
             if highlight_div:
                 highlight = highlight_div.text.strip()
-                
+
                 ## ID der Hervorhebung
-                highlight_id = None
                 if highlight_div.get('id'):
                     highlight_id = highlight_div.get('id').replace('highlight-', '')
             


### PR DESCRIPTION
## Summary
- fix `highlight_id` being undefined in comment parsing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684025c904f0832ead2056ec3cd28b26